### PR TITLE
reference parent stack

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,11 +6,9 @@ metadata:
   supportUrl: https://github.com/devfile-samples/devfile-support#support-information
   attributes:
     alpha.dockerimage-port: 8081
-starterProjects:
-  - name: python-example
-    git:
-      remotes:
-        origin: https://github.com/odo-devfiles/python-ex
+parent:
+  id: python
+  registryUrl: "https://registry.devfile.io"
 components:
   - name: outerloop-build
     image:
@@ -22,36 +20,7 @@ components:
   - name: outerloop-deploy
     kubernetes:
       uri: outerloop-deploy.yaml
-  - name: py-web
-    container:
-      image: quay.io/eclipse/che-python-3.7:nightly
-      mountSources: true
-      endpoints:
-        - name: web
-          targetPort: 8080
 commands:
-  - id: pip-install-requirements
-    exec:
-      commandLine: pip install --user -r requirements.txt
-      group:
-        kind: build
-        isDefault: true
-      component: py-web
-  - id: run-app
-    exec:
-      commandLine: "python app.py"
-      workingDir: ${PROJECTS_ROOT}
-      component: py-web
-      group:
-        kind: run
-        isDefault: true
-  - id: debugpy
-    exec:
-      commandLine: "pip install --user debugpy && python -m debugpy --listen 0.0.0.0:${DEBUG_PORT} app.py"
-      workingDir: ${PROJECTS_ROOT}
-      component: py-web
-      group:
-        kind: debug
   - id: build-image
     apply:
       component: outerloop-build


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

For issue: https://github.com/devfile/api/issues/715
For the samples, we want to suggest an actual usage, we should reference parent stack instead of copy the parent devfile content inside the main devfile. 