### PR TITLE
Fix cannot import name 'json' from 'itsdangerous'" cause by itsdangerous update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==1.1.2
+itsdangerous==2.0.1
 waitress==2.0.0


### PR DESCRIPTION
please refer to https://serverfault.com/questions/1094062/error-from-itsdangerous-import-json-as-json-importerror-cannot-import-name-j