### PR TITLE
update flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask==1.1.2
+Flask==2.0.0
 itsdangerous==2.0.1
 waitress==2.0.0


### PR DESCRIPTION
A component used in Flask 1.1.2 has been deprecated. 

This results in this error when you run the container 
```cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.10/site-packages/jinja2/__init__.py)```

Upgrading the Flask version to 2.0 fixes the error

How to test 
```
docker build -f docker/Dockerfile  -t test .
docker run -p 8081:8081 test
```

before the patch you get the error, after the patch it works. 