### PR TITLE
[DEVHAS-339] Remove resource limits

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -19,7 +19,7 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
-          resource:
+          resources:
             requests:
               memory: "50Mi"
               cpu: "10m"

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -19,10 +19,6 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
 ---
 kind: Service
 apiVersion: v1

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -19,6 +19,10 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
+          resource:
+            requests:
+              memory: "50Mi"
+              cpu: "10m"
 ---
 kind: Service
 apiVersion: v1

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -31,9 +31,7 @@ components:
   - name: kubernetes-deploy
     attributes:
       deployment/replicas: 1
-      deployment/cpuLimit: '100m'
       deployment/cpuRequest: 10m
-      deployment/memoryLimit: 100Mi
       deployment/memoryRequest: 50Mi
       deployment/container-port: 8081
     kubernetes:


### PR DESCRIPTION
# What does this PR do?

Removes the resource limits from the devfile and `deploy.yaml` kubernetes deploy spec to ensure compatibility to the Red Hat Hybrid Application Console when setting the resource requests.

In addition, the resource requests defined in the devfile has now been added to `deploy.yaml` in preparation for deprecating the `attribute` fields shared between the two files.