### PR TITLE
Update port from 8081 to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Creating an application with a Python code sample
 
-**Note:** The Python code sample uses the **8081** HTTP port.
+**Note:** The Python code sample uses the **8080** HTTP port.
 
 Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Dockerfile` and how they contribute to your build. You can find these files at the following URLs:
 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           image: python-image:latest
           ports:
             - name: http
-              containerPort: 8081
+              containerPort: 8080
               protocol: TCP
           resources:
             requests:
@@ -30,9 +30,9 @@ metadata:
   name: my-python
 spec:
 ports:
-  - name: http-8081
-    port: 8081
+  - name: http-8080
+    port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
 selector:
   app: python-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -33,12 +33,12 @@ components:
       deployment/replicas: 1
       deployment/cpuRequest: 10m
       deployment/memoryRequest: 50Mi
-      deployment/container-port: 8081
+      deployment/container-port: 8080
     kubernetes:
       uri: deploy.yaml
       endpoints:
-      - name: http-8081
-        targetPort: 8081
+      - name: http-8080
+        targetPort: 8080
         path: /
 commands:
   - id: build-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM registry.access.redhat.com/ubi9/python-39:1-117.1684741281
 
-# By default, listen on port 8081
-EXPOSE 8081/tcp
-ENV FLASK_PORT=8081
+# By default, listen on port 8080
+EXPOSE 8080/tcp
+ENV FLASK_PORT=8080
 
 # Set the working directory in the container
 WORKDIR /projects


### PR DESCRIPTION
- Updates the devfile sample port from 8081 to 8080
- Doesnt update the attribute alpha.dockerimage-port: 8081 because of backward compatibility in ODC earlier versions. We dont want to backport devfile/library update that far back.