### PR TITLE
Enable TLS for version 1

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -29,10 +29,10 @@ apiVersion: v1
 metadata:
   name: my-python
 spec:
-ports:
-  - name: http-8081
-    port: 8081
-    protocol: TCP
-    targetPort: 8081
-selector:
-  app: python-app
+  ports:
+    - name: http-8081
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: python-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -37,9 +37,10 @@ components:
     kubernetes:
       uri: deploy.yaml
       endpoints:
-      - name: http-8081
-        targetPort: 8081
-        path: /
+        - name: http-8081
+          targetPort: 8081
+          path: /
+          secure: true
 commands:
   - id: build-image
     apply:


### PR DESCRIPTION
# Description

Set `secure` to `true` to prompt devtools, such as ODC, to create a route with tls enabled.

This should enable TLS on OpenShift for this sample when web console has been patched: https://github.com/devfile/api/issues/1270#issuecomment-1866424653

fixes part of devfile/api#1270