### PR TITLE
Fix parent stack version

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -20,6 +20,7 @@ metadata:
 parent:
   id: python
   registryUrl: 'https://registry.devfile.io'
+  version: 2.1.0
 components:
   - name: image-build
     image:


### PR DESCRIPTION
After the merge of https://github.com/devfile/registry/pull/358 the default version of the `python` (parent) stack has been changed to `2.2.0` which uses the `schemaVersion` -> `2.2.2`. This version is not compatible with HAS until the https://github.com/redhat-appstudio/infra-deployments/pull/3587 is merged (includes the necessary update of registry-support https://github.com/devfile/registry-support/commit/c12332d7588042539f49e48fdfccdc877f2f332a which adds the support of `2.2.1` & `2.2.2`.

This PR simply specifies the previous default version of parent in order to avoid errors on the CDQ side.